### PR TITLE
Improve error context

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,26 @@ Why did we call them decoders? They're basically a function that takes an `any` 
 
 With custom decoders, however, you are responsible that they don't thrown runtime errors, a guarantee that `tucson`'s primitives will keep for you.
 
+### Errors
+
+When decoders fail, they provide to-the-point error messages that help pin down errors easily. They can be referenced instantly to open up a discussion around frontend-backend contracts and find bugs in both places.
+
+A typical error message looks like this:
+
+```
+{
+  type: "error",
+  value: [
+    // There can be multiple error messages
+    {
+      path: [ "address", "street" ],
+      error: "expected string",
+      received: 2
+    }
+  ]
+}
+```
+
 ## Alternatives
 
 `tucson` is inspired by and an alternative to the following projects:

--- a/src/__tests__/nonprimitives.test.ts
+++ b/src/__tests__/nonprimitives.test.ts
@@ -16,7 +16,16 @@ describe("object", () => {
         name: tucson.string,
         age: tucson.number,
       })({ name: "Paul" }),
-    ).toEqual({ type: "error", value: "error decoding field 'age': expected a number, received: undefined" });
+    ).toEqual({
+      type: "error",
+      value: [
+        {
+          path: ["age"],
+          error: "expected number",
+          received: undefined,
+        },
+      ],
+    });
   });
 
   test("fails to decode falsy values without runtime errors", () => {
@@ -24,7 +33,16 @@ describe("object", () => {
       tucson.object({
         name: tucson.string,
       })(null),
-    ).toEqual({ type: "error", value: "" });
+    ).toEqual({
+      type: "error",
+      value: [
+        {
+          path: [],
+          error: "expected object",
+          received: null,
+        },
+      ],
+    });
   });
 });
 
@@ -36,11 +54,26 @@ describe("array", () => {
   test("fails to decode array with a single bad entry", () => {
     expect(tucson.array(tucson.string)(["a", 0, "c"])).toEqual({
       type: "error",
-      value: "expected array item at index 1 to decode correctly, received: 0",
+      value: [
+        {
+          path: ["1"],
+          error: "expected string",
+          received: 0,
+        },
+      ],
     });
   });
 
   test("fails to decode a falsy value without runtime errors", () => {
-    expect(tucson.array(tucson.string)(null)).toEqual({ type: "error", value: "expected array, received: null" });
+    expect(tucson.array(tucson.string)(null)).toEqual({
+      type: "error",
+      value: [
+        {
+          path: [],
+          error: "expected array",
+          received: null,
+        },
+      ],
+    });
   });
 });

--- a/src/__tests__/primitives.test.ts
+++ b/src/__tests__/primitives.test.ts
@@ -6,7 +6,16 @@ describe("string", () => {
   });
 
   test("unsuccessful string", () => {
-    expect(tucson.string(0)).toEqual({ type: "error", value: "expected a string, received: 0" });
+    expect(tucson.string(0)).toEqual({
+      type: "error",
+      value: [
+        {
+          path: [],
+          error: "expected string",
+          received: 0,
+        },
+      ],
+    });
   });
 });
 
@@ -16,7 +25,16 @@ describe("number", () => {
   });
 
   test("unsuccessful number", () => {
-    expect(tucson.number("0")).toEqual({ type: "error", value: `expected a number, received: "0"` });
+    expect(tucson.number("0")).toEqual({
+      type: "error",
+      value: [
+        {
+          path: [],
+          error: "expected number",
+          received: "0",
+        },
+      ],
+    });
   });
 });
 
@@ -26,7 +44,16 @@ describe("boolean", () => {
   });
 
   test("unsuccessful boolean", () => {
-    expect(tucson.boolean(70)).toEqual({ type: "error", value: `expected a boolean, received: 70` });
+    expect(tucson.boolean(70)).toEqual({
+      type: "error",
+      value: [
+        {
+          path: [],
+          error: "expected boolean",
+          received: 70,
+        },
+      ],
+    });
   });
 });
 
@@ -36,7 +63,15 @@ describe("null", () => {
   });
 
   test("unsuccessful null", () => {
-    expect(tucson.null("Sales")).toEqual(tucson.error(`expected null, received: "Sales"`));
+    expect(tucson.null("Sales")).toEqual(
+      tucson.error([
+        {
+          path: [],
+          error: "expected null",
+          received: "Sales",
+        },
+      ]),
+    );
   });
 });
 
@@ -46,7 +81,15 @@ describe("undefined", () => {
   });
 
   test("unsuccessful undefined", () => {
-    expect(tucson.undefined("Sales")).toEqual(tucson.error(`expected undefined, received: "Sales"`));
+    expect(tucson.undefined("Sales")).toEqual(
+      tucson.error([
+        {
+          path: [],
+          error: "expected undefined",
+          received: "Sales",
+        },
+      ]),
+    );
   });
 });
 
@@ -56,6 +99,15 @@ describe("literal", () => {
   });
 
   test("unsuccessful literal", () => {
-    expect(tucson.literal("Sales")("Foo")).toEqual(tucson.error(`expected literal "Sales", received: "Foo"`));
+    expect(tucson.literal("Sales")("Foo")).toEqual({
+      type: "error",
+      value: [
+        {
+          path: [],
+          error: 'expected literal "Sales"',
+          received: "Foo",
+        },
+      ],
+    });
   });
 });

--- a/src/__tests__/transforms.test.ts
+++ b/src/__tests__/transforms.test.ts
@@ -7,7 +7,16 @@ describe("map", () => {
   });
 
   test("keeps an unsuccessful decode intact", () => {
-    expect(tucson.map(tucson.string, Number)(0)).toEqual({ type: "error", value: "expected a string, received: 0" });
+    expect(tucson.map(tucson.string, Number)(0)).toEqual({
+      type: "error",
+      value: [
+        {
+          path: [],
+          error: "expected string",
+          received: 0,
+        },
+      ],
+    });
   });
 });
 
@@ -26,7 +35,13 @@ describe("flatMap", () => {
   test("keeps an unsuccessful decode intact", () => {
     expect(tucson.flatMap(tucson.string, () => tucson.succeed("default"))(0)).toEqual({
       type: "error",
-      value: "expected a string, received: 0",
+      value: [
+        {
+          path: [],
+          error: "expected string",
+          received: 0,
+        },
+      ],
     });
   });
 });
@@ -39,8 +54,28 @@ describe("ensure", () => {
       [p => p.age > p.name.length, "unexpected age"],
     );
 
-    expect(personDecoder({ name: "Foo", age: 32 })).toEqual(error("name is too far from perfect"));
-    expect(personDecoder({ name: "IevgenFoo", age: 5 })).toEqual(error("unexpected age"));
+    expect(personDecoder({ name: "Foo", age: 32 })).toEqual({
+      type: "error",
+      value: [
+        {
+          path: [],
+          received: { name: "Foo", age: 32 },
+          error: "name is too far from perfect",
+        },
+      ],
+    });
+    expect(personDecoder({ name: "IevgenFoo", age: 5 })).toEqual(
+      error([
+        {
+          path: [],
+          received: {
+            name: "IevgenFoo",
+            age: 5,
+          },
+          error: "unexpected age",
+        },
+      ]),
+    );
     expect(personDecoder({ name: "IevgenFoo", age: 33 })).toEqual(success({ name: "IevgenFoo", age: 33 }));
   });
 
@@ -51,9 +86,24 @@ describe("ensure", () => {
     });
 
     expect(personDecoder({ name: "Foo", age: 32 })).toEqual(
-      error("error decoding field 'name': name is too far from perfect"),
+      error([
+        {
+          path: ["name"],
+          received: "Foo",
+          error: "name is too far from perfect",
+        },
+      ]),
     );
-    expect(personDecoder({ name: "IevgenFoo", age: -15 })).toEqual(error("error decoding field 'age': negative age"));
+    expect(personDecoder({ name: "IevgenFoo", age: -15 })).toEqual({
+      type: "error",
+      value: [
+        {
+          path: ["age"],
+          error: "negative age",
+          received: -15,
+        },
+      ],
+    });
     expect(personDecoder({ name: "IevgenFoo", age: 33 })).toEqual(success({ name: "IevgenFoo", age: 33 }));
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,14 @@
 export { Decoder, Result, success, error } from "./types";
-export { succeed, fail, string, number, boolean, any, literal, nullDecoder as null, undefinedDecoder as undefined } from "./primitives";
-export { object, array, field, dictionary } from "./nonprimitives";
+export {
+  succeed,
+  fail,
+  string,
+  number,
+  boolean,
+  any,
+  literal,
+  nullDecoder as null,
+  undefinedDecoder as undefined,
+} from "./primitives";
+export { object, array, dictionary } from "./nonprimitives";
 export { map, flatMap, map2, map3, lazy, oneOf, optional, ensure } from "./transforms";

--- a/src/primitives.ts
+++ b/src/primitives.ts
@@ -10,7 +10,14 @@ export const succeed = <T>(value: T): Decoder<T> => _ => success(value);
  * Create a decoder that always fails with a given error (this is optional).
  * See ./examples/flatMap.ts to see why this is useful.
  */
-export const fail = <T>(errorMsg: string = "Failure"): Decoder<T> => _ => error(errorMsg);
+export const fail = <T>(errorMsg: string = "Failure"): Decoder<T> => val =>
+  error([
+    {
+      path: [],
+      received: val,
+      error: errorMsg,
+    },
+  ]);
 
 /**
  * Create a decoder that always succeeds with value it decodes, leaving it as an `any` type.
@@ -26,12 +33,26 @@ export const any: Decoder<any> = val => ({
 export const literal = <T extends string | boolean | number>(literal: T): Decoder<T> => val =>
   val === literal
     ? success(literal)
-    : error(`expected literal ${JSON.stringify(literal)}, received: ${JSON.stringify(val)}`);
+    : error([
+        {
+          path: [],
+          error: `expected literal ${JSON.stringify(literal)}`,
+          received: val,
+        },
+      ]);
 /**
  * Decode a string
  */
 export const string: Decoder<string> = val =>
-  typeof val === "string" ? success(val) : error(`expected a string, received: ${JSON.stringify(val)}`);
+  typeof val === "string"
+    ? success(val)
+    : error([
+        {
+          path: [],
+          error: "expected string",
+          received: val,
+        },
+      ]);
 
 /**
  * Decode a number.
@@ -40,24 +61,56 @@ export const string: Decoder<string> = val =>
  * validations for floating point numbers.
  */
 export const number: Decoder<number> = val =>
-  typeof val === "number" ? success(val) : error(`expected a number, received: ${JSON.stringify(val)}`);
+  typeof val === "number"
+    ? success(val)
+    : error([
+        {
+          path: [],
+          error: "expected number",
+          received: val,
+        },
+      ]);
 
 /**
  * Decode a boolean
  */
 export const boolean: Decoder<boolean> = val =>
-  typeof val === "boolean" ? success(val) : error(`expected a boolean, received: ${JSON.stringify(val)}`);
+  typeof val === "boolean"
+    ? success(val)
+    : error([
+        {
+          path: [],
+          error: "expected boolean",
+          received: val,
+        },
+      ]);
 
 /**
  * Decode a null value. This is named `nullDecoder` instead of `null` to not override the global value.
  * Recommended usage outside the library would be `tucson.null`.
  */
 export const nullDecoder: Decoder<null> = val =>
-  val === null ? success(val) : error(`expected null, received: ${JSON.stringify(val)}`);
+  val === null
+    ? success(val)
+    : error([
+        {
+          path: [],
+          error: "expected null",
+          received: val,
+        },
+      ]);
 
 /**
  * Decode an undefined value. This is named `undefinedDecoder` instead of `null` to not override the global value.
  * Recommended usage outside the library would be `tucson.undefined`.
  */
 export const undefinedDecoder: Decoder<undefined> = val =>
-  typeof val === "undefined" ? success(val) : error(`expected undefined, received: ${JSON.stringify(val)}`);
+  typeof val === "undefined"
+    ? success(val)
+    : error([
+        {
+          path: [],
+          error: "expected undefined",
+          received: val,
+        },
+      ]);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,9 @@
-export type Result<T> = { type: "error"; value: string } | { type: "success"; value: T };
+export type Result<E, T> = { type: "error"; value: E } | { type: "success"; value: T };
 
 /**
  * Successful result constructor
  */
-export const success = <T>(value: T): Result<T> => ({
+export const success = <E, T>(value: T): Result<E, T> => ({
   type: "success",
   value,
 });
@@ -11,9 +11,18 @@ export const success = <T>(value: T): Result<T> => ({
 /**
  * Error result constructor
  */
-export const error = <T>(value: string): Result<T> => ({
+export const error = <E, T>(value: E): Result<E, T> => ({
   type: "error",
   value,
 });
 
-export type Decoder<T> = (a: any) => Result<T>;
+/**
+ * Decoder error
+ */
+export interface DecodeError {
+  path: string[];
+  received: any;
+  error: string;
+}
+
+export type Decoder<T> = (a: any) => Result<DecodeError[], T>;


### PR DESCRIPTION
Improving error context inside decoders so that this will happen:

```js
tucson.object({
  address: tucson.object({
    street: tucson.string
  })
})({
  address: {
    street: 2
  }
})
```

will log:

```
{
  type: "error",
  value: {
    path: [ "address", "street" ],
    expectType: "string",
    received: 2
  }
}
```

We can use this to display accurate error messages with formatting logic that lives outside of this library.

The one method that loses some error context is `ensure`, so I will mention in the future docs that you might want to use `flatMap` instead to have more control over errors. For most practical use-cases, though, this should be all one needs.